### PR TITLE
Update GitHub Actions configuration to allow write access to packages

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,6 +1,6 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,8 +1,8 @@
-name: GitHub Actions Demo
+name: Go Tests
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
 on: [pull_request]
 jobs:
-  Explore-GitHub-Actions:
+  go-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -16,6 +17,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions configuration to allow write access to packages. This is necessary for the project to publish packages to the GitHub Container Registry. 