### PR TITLE
Use Default Semantic Version if config version is not found.

### DIFF
--- a/pkg/servers/trace.go
+++ b/pkg/servers/trace.go
@@ -35,10 +35,11 @@ func NewTraceService(cfg Config, svs map[string]semconv.SemanticVersion) *TraceS
 	}
 	matches := []matchDef{}
 	for _, match := range cfg.Trace {
-		if match.SemanticVersion == "" {
+		groups, ok := svs[match.SemanticVersion]
+		if !ok {
 			match.SemanticVersion = semconv.DefaultVersion
 		}
-		matches = append(matches, newMatchDef(match, svs[match.SemanticVersion].Groups))
+		matches = append(matches, newMatchDef(match, groups.Groups))
 	}
 
 	return &TraceServer{


### PR DESCRIPTION
Currently, it will use no version if a config is used with an incorrect Semantic version, e.g. `"v1.20.0"`.  This change makes any not-found version use the default.

The correct version string should be a full URL, e.g. `"https://opentelemetry.io/schemas/1.21.0"`